### PR TITLE
Fix CEO column migration to actually add the column

### DIFF
--- a/migrations/20250916084200_add_ceo_column.sql
+++ b/migrations/20250916084200_add_ceo_column.sql
@@ -1,4 +1,4 @@
--- Add CEO column to ticker_details table if it doesn't exist
--- SQLite doesn't support IF NOT EXISTS for ALTER TABLE ADD COLUMN
--- This migration is a no-op if the column already exists
-SELECT 1;
+-- Add CEO column to ticker_details table
+-- Note: SQLite doesn't support IF NOT EXISTS for ALTER TABLE ADD COLUMN
+-- If this migration has already been applied, it will fail with an error
+ALTER TABLE ticker_details ADD COLUMN ceo TEXT;


### PR DESCRIPTION
The migration file was previously a no-op (just 'SELECT 1;'), which meant the CEO column would never be created on fresh database installations. This caused runtime errors when the code tried to query the ceo column from the ticker_details table.

This commit replaces the no-op with the actual ALTER TABLE statement to add the ceo TEXT column to the ticker_details table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)