### PR TITLE
Add FetchHistoricalExchangeRates command and Justfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,16 @@ Edit the `config.toml` file to add new tickers to either the `us_tickers` or `no
 ### Updating Exchange Rates
 
 ```bash
+# Fetch current exchange rates
 cargo run -- ExportRates
+
+# Backfill historical exchange rates for a date range
+cargo run -- fetch-historical-exchange-rates --from 2024-01-01 --to 2024-12-31
+
+# This command will:
+# - Fetch daily exchange rates for common currency pairs (EUR, GBP, JPY, CHF, etc.)
+# - Store rates in the database with their respective dates
+# - Enable accurate historical market cap comparisons with correct FX rates
 ```
 
 ### Generating Combined Market Cap Reports
@@ -250,6 +259,33 @@ Symbol changes are fetched from the Financial Modeling Prep API and stored in th
 - Add comments showing the old ticker and change date
 - Mark changes as applied in the database to avoid reprocessing
 
+### Using the Justfile
+
+The project includes a `justfile` with common development tasks. If you have `just` installed:
+
+```bash
+# List all available commands
+just --list
+
+# Common tasks
+just build          # Build the project
+just test           # Run all tests
+just fmt            # Format all code
+just lint           # Run clippy linter
+just quality        # Run all quality checks (fmt, lint, deny)
+
+# Application commands
+just rates                      # Fetch current exchange rates
+just rates-historical 2024-01-01 2024-12-31  # Fetch historical rates
+just marketcaps                 # Fetch and export market caps
+just compare 2025-01-01 2025-02-01  # Compare two dates
+just ytd                        # Year-to-date comparison
+
+# Database commands
+just db             # Open SQLite shell
+just db-stats       # Show database statistics
+```
+
 ### Code Formatting
 
 After making code changes, always run the Rust formatter to ensure code style consistency:
@@ -282,13 +318,14 @@ The application supports these main commands:
 - `MarketCaps` (default) - Fetch and update market cap data
 - `ExportCombined` - Export combined market cap report to CSV
 - `ExportRates` - Export exchange rates to CSV
+- `fetch-historical-exchange-rates` - Backfill historical exchange rates for a date range
 - `FetchHistoricalMarketCaps` - Fetch historical yearly data
 - `FetchMonthlyHistoricalMarketCaps` - Fetch historical monthly data
 - `fetch-specific-date-market-caps` - Fetch market caps for a specific date
 - `compare-market-caps` - Compare market caps between two dates
 - `generate-charts` - Generate visualization charts from comparison data
 - `ListCurrencies` - List all available currencies
-- `Details` - Fetch company details
-- `ReadConfig` - Display configuration
+- `check-symbol-changes` - Check for ticker symbol changes
+- `apply-symbol-changes` - Apply pending symbol changes to config
 
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ cargo run -- fetch-historical-market-caps 2023 2025
 cargo run -- fetch-monthly-historical-market-caps 2023 2025
 ```
 
+Backfill historical exchange rates:
+
+```bash
+# Fetch historical exchange rates for a date range
+cargo run -- fetch-historical-exchange-rates --from 2024-01-01 --to 2024-12-31
+
+# This will:
+# - Fetch daily exchange rates for common currency pairs (EUR, GBP, JPY, CHF, etc.)
+# - Store rates in the database with their respective dates
+# - Enable accurate historical market cap comparisons with correct FX rates
+
+# Backfill last year of exchange rates
+cargo run -- fetch-historical-exchange-rates --from $(date -d "1 year ago" +%Y-%m-%d) --to $(date +%Y-%m-%d)
+```
+
 ## Database Browsing
 
 ### Accessing the SQLite Database

--- a/justfile
+++ b/justfile
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: 2025 Joost van der Laan <joost@fashionunited.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Top200-rs Justfile - Common development tasks
+# Run `just --list` to see all available commands
+
+# Default recipe - show available commands
+default:
+    @just --list
+
+# =============================================================================
+# Build Commands
+# =============================================================================
+
+# Build the project in debug mode
+build:
+    nix develop --command cargo build
+
+# Build the project in release mode
+build-release:
+    nix develop --command cargo build --release
+
+# Check code without building
+check:
+    nix develop --command cargo check
+
+# Clean build artifacts
+clean:
+    nix develop --command cargo clean
+
+# =============================================================================
+# Testing
+# =============================================================================
+
+# Run all tests
+test:
+    nix develop --command cargo test
+
+# Run tests with output
+test-verbose:
+    nix develop --command cargo test -- --nocapture
+
+# Run a specific test by name
+test-one name:
+    nix develop --command cargo test {{name}}
+
+# Run tests with coverage report
+test-coverage:
+    nix develop --command cargo tarpaulin --out lcov --output-dir coverage
+
+# =============================================================================
+# Linting & Formatting
+# =============================================================================
+
+# Format all code
+fmt:
+    nix develop --command cargo fmt --all
+
+# Check formatting without changes
+fmt-check:
+    nix develop --command cargo fmt --all -- --check
+
+# Run clippy linter
+lint:
+    nix develop --command cargo clippy
+
+# Run clippy with all warnings as errors
+lint-strict:
+    nix develop --command cargo clippy -- -D warnings
+
+# Check license compliance
+license-check:
+    reuse lint
+
+# Run cargo-deny for dependency checks
+deny:
+    nix develop --command cargo deny check
+
+# Run all quality checks (format, lint, deny)
+quality: fmt lint deny
+
+# =============================================================================
+# Database Operations
+# =============================================================================
+
+# Open SQLite database shell
+db:
+    sqlite3 data.db
+
+# Show database schema
+db-schema:
+    sqlite3 data.db ".schema"
+
+# Show all tables
+db-tables:
+    sqlite3 data.db ".tables"
+
+# Show database statistics
+db-stats:
+    @echo "=== Database Statistics ==="
+    @echo "Tables and row counts:"
+    @sqlite3 data.db "SELECT 'market_caps', COUNT(*) FROM market_caps;"
+    @sqlite3 data.db "SELECT 'forex_rates', COUNT(*) FROM forex_rates;"
+    @sqlite3 data.db "SELECT 'currencies', COUNT(*) FROM currencies;"
+    @sqlite3 data.db "SELECT 'ticker_details', COUNT(*) FROM ticker_details;"
+    @sqlite3 data.db "SELECT 'symbol_changes', COUNT(*) FROM symbol_changes;"
+
+# =============================================================================
+# Application Commands
+# =============================================================================
+
+# Run the application (default: market caps)
+run *args:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- {{args}}
+
+# Show help
+help:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- --help
+
+# Fetch current exchange rates
+rates:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- ExportRates
+
+# Fetch historical exchange rates (example: just rates-historical 2024-01-01 2024-12-31)
+rates-historical from to:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- fetch-historical-exchange-rates --from {{from}} --to {{to}}
+
+# Backfill exchange rates for last year
+rates-backfill-year:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- fetch-historical-exchange-rates --from $(date -d "1 year ago" +%Y-%m-%d) --to $(date +%Y-%m-%d)
+
+# Fetch market caps for today
+marketcaps:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- ExportCombined
+
+# Fetch market caps for a specific date (example: just marketcaps-date 2025-01-15)
+marketcaps-date date:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- fetch-specific-date-market-caps {{date}}
+
+# Fetch historical market caps for a year range
+marketcaps-historical start end:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- FetchHistoricalMarketCaps {{start}} {{end}}
+
+# Compare market caps between two dates
+compare from to:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- compare-market-caps --from {{from}} --to {{to}}
+
+# Generate visualization charts
+charts from to:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- generate-charts --from {{from}} --to {{to}}
+
+# Full comparison workflow: fetch both dates, compare, and generate charts
+compare-full from to:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- fetch-specific-date-market-caps {{from}}
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- fetch-specific-date-market-caps {{to}}
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- compare-market-caps --from {{from}} --to {{to}}
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- generate-charts --from {{from}} --to {{to}}
+
+# Year-to-date comparison
+ytd:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- fetch-specific-date-market-caps $(date -d "last year" +%Y)-12-31
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- fetch-specific-date-market-caps $(date +%Y-%m-%d)
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- compare-market-caps --from $(date -d "last year" +%Y)-12-31 --to $(date +%Y-%m-%d)
+
+# List all currencies
+currencies:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- ListCurrencies
+
+# Check for symbol changes
+symbol-check:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- check-symbol-changes
+
+# Preview symbol changes (dry run)
+symbol-preview:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- apply-symbol-changes --dry-run
+
+# Apply symbol changes automatically
+symbol-apply:
+    DATABASE_URL=sqlite:data.db nix develop --command cargo run -- apply-symbol-changes --auto-apply
+
+# =============================================================================
+# Development Workflow
+# =============================================================================
+
+# Enter nix development shell
+dev:
+    nix develop
+
+# Watch for changes and rebuild
+watch:
+    nix develop --command cargo watch -x check
+
+# Full CI check (what CI runs)
+ci: fmt-check lint test deny
+
+# Pre-commit hook simulation
+pre-commit: fmt lint test
+
+# =============================================================================
+# Documentation
+# =============================================================================
+
+# Generate and open documentation
+docs:
+    nix develop --command cargo doc --open
+
+# Generate documentation without opening
+docs-build:
+    nix develop --command cargo doc
+
+# =============================================================================
+# Utility
+# =============================================================================
+
+# Update nix flake
+update-flake:
+    nix flake update
+
+# Show outdated dependencies
+outdated:
+    nix develop --command cargo outdated
+
+# Count lines of code
+loc:
+    @echo "=== Lines of Code ==="
+    @find src -name "*.rs" | xargs wc -l | tail -1
+    @echo ""
+    @echo "=== By file ==="
+    @find src -name "*.rs" | xargs wc -l | sort -n
+
+# Show project structure
+tree:
+    @tree -I 'target|output|.git|coverage' --dirsfirst

--- a/src/exchange_rates.rs
+++ b/src/exchange_rates.rs
@@ -4,7 +4,8 @@
 use crate::api::FMPClient;
 use crate::currencies::insert_forex_rate;
 use anyhow::Result;
-use chrono::Utc;
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use indicatif::{ProgressBar, ProgressStyle};
 use sqlx::sqlite::SqlitePool;
 
 /// Update exchange rates in the database
@@ -31,4 +32,148 @@ pub async fn update_exchange_rates(fmp_client: &FMPClient, pool: &SqlitePool) ->
 
     println!("✅ Exchange rates updated in database");
     Ok(())
+}
+
+/// Currency pairs commonly needed for market cap conversions
+const COMMON_FOREX_PAIRS: &[&str] = &[
+    "EURUSD", "GBPUSD", "JPYUSD", "CHFUSD", "SEKUSD", "DKKUSD", "NOKUSD", "HKDUSD", "CNYUSD",
+    "BRLUSD", "CADUSD", "ILSUSD", "ZARUSD", "INRUSD", "KRWUSD", "TRYUSD", "PLNUSD", "TWDUSD",
+];
+
+/// Fetch and store historical exchange rates for a date range
+pub async fn fetch_historical_exchange_rates(
+    fmp_client: &FMPClient,
+    pool: &SqlitePool,
+    from_date: &str,
+    to_date: &str,
+) -> Result<()> {
+    println!(
+        "Fetching historical exchange rates from {} to {}",
+        from_date, to_date
+    );
+
+    // Get available forex pairs to validate
+    println!("Fetching available forex pairs...");
+    let available_pairs = match fmp_client.get_available_forex_pairs().await {
+        Ok(pairs) => {
+            println!("✅ Found {} available forex pairs", pairs.len());
+            pairs
+        }
+        Err(e) => {
+            eprintln!(
+                "⚠️  Could not fetch available pairs, using common pairs: {}",
+                e
+            );
+            COMMON_FOREX_PAIRS.iter().map(|s| s.to_string()).collect()
+        }
+    };
+
+    // Filter to common pairs that are available
+    let pairs_to_fetch: Vec<&str> = COMMON_FOREX_PAIRS
+        .iter()
+        .filter(|p| available_pairs.iter().any(|ap| ap == *p))
+        .copied()
+        .collect();
+
+    if pairs_to_fetch.is_empty() {
+        println!("Using all common forex pairs...");
+    } else {
+        println!("Fetching {} currency pairs...", pairs_to_fetch.len());
+    }
+
+    let pairs = if pairs_to_fetch.is_empty() {
+        COMMON_FOREX_PAIRS.to_vec()
+    } else {
+        pairs_to_fetch
+    };
+
+    // Set up progress bar
+    let progress = ProgressBar::new(pairs.len() as u64);
+    progress.set_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>3}/{len:3} {msg}")
+            .unwrap()
+            .progress_chars("=>-"),
+    );
+
+    let mut total_rates = 0usize;
+    let mut failed_pairs = Vec::new();
+
+    for pair in &pairs {
+        progress.set_message(format!("Fetching {}...", pair));
+
+        match fmp_client
+            .get_historical_exchange_rates(pair, from_date, to_date)
+            .await
+        {
+            Ok(response) => {
+                let symbol_with_slash = format_pair_with_slash(&response.symbol);
+
+                for data in &response.historical {
+                    // Parse date and convert to Unix timestamp
+                    if let Ok(date) = NaiveDate::parse_from_str(&data.date, "%Y-%m-%d") {
+                        let datetime =
+                            NaiveDateTime::new(date, NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+                        let timestamp = datetime.and_utc().timestamp();
+
+                        // Use close price as the rate (most commonly used)
+                        insert_forex_rate(
+                            pool,
+                            &symbol_with_slash,
+                            data.close,
+                            data.close,
+                            timestamp,
+                        )
+                        .await?;
+                        total_rates += 1;
+                    }
+                }
+            }
+            Err(e) => {
+                failed_pairs.push((pair.to_string(), e.to_string()));
+            }
+        }
+
+        progress.inc(1);
+    }
+
+    progress.finish_with_message("Done");
+
+    // Print summary
+    println!("\n📊 Historical Exchange Rates Summary:");
+    println!("   Date range: {} to {}", from_date, to_date);
+    println!("   Pairs processed: {}", pairs.len() - failed_pairs.len());
+    println!("   Total rates stored: {}", total_rates);
+
+    if !failed_pairs.is_empty() {
+        println!("\n⚠️  Failed to fetch {} pairs:", failed_pairs.len());
+        for (pair, error) in &failed_pairs {
+            println!("   {} - {}", pair, error);
+        }
+    }
+
+    println!("\n✅ Historical exchange rates updated in database");
+    Ok(())
+}
+
+/// Convert a pair like "EURUSD" to "EUR/USD"
+fn format_pair_with_slash(pair: &str) -> String {
+    if pair.len() == 6 && !pair.contains('/') {
+        format!("{}/{}", &pair[0..3], &pair[3..6])
+    } else {
+        pair.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_pair_with_slash() {
+        assert_eq!(format_pair_with_slash("EURUSD"), "EUR/USD");
+        assert_eq!(format_pair_with_slash("GBPUSD"), "GBP/USD");
+        assert_eq!(format_pair_with_slash("EUR/USD"), "EUR/USD");
+        assert_eq!(format_pair_with_slash("JPYUSD"), "JPY/USD");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,15 @@ enum Commands {
     ListEu,
     /// Export exchange rates to CSV
     ExportRates,
+    /// Fetch historical exchange rates for a date range
+    FetchHistoricalExchangeRates {
+        /// Start date (YYYY-MM-DD format)
+        #[arg(long)]
+        from: String,
+        /// End date (YYYY-MM-DD format)
+        #[arg(long)]
+        to: String,
+    },
     /// Fetch historical market caps
     FetchHistoricalMarketCaps { start_year: i32, end_year: i32 },
     /// Fetch monthly historical market caps
@@ -113,6 +122,12 @@ async fn main() -> Result<()> {
                 .expect("FINANCIALMODELINGPREP_API_KEY must be set");
             let fmp_client = api::FMPClient::new(api_key);
             exchange_rates::update_exchange_rates(&fmp_client, &pool).await?;
+        }
+        Some(Commands::FetchHistoricalExchangeRates { from, to }) => {
+            let api_key = env::var("FINANCIALMODELINGPREP_API_KEY")
+                .expect("FINANCIALMODELINGPREP_API_KEY must be set");
+            let fmp_client = api::FMPClient::new(api_key);
+            exchange_rates::fetch_historical_exchange_rates(&fmp_client, &pool, &from, &to).await?;
         }
         Some(Commands::FetchHistoricalMarketCaps {
             start_year,


### PR DESCRIPTION
- Add new CLI command to backfill historical exchange rates for a date range
- Fetch daily FX rates for common currency pairs (EUR, GBP, JPY, CHF, etc.)
- Store historical rates in database for accurate historical comparisons
- Add Justfile with 40+ common development tasks:
  - Build, test, lint, format commands
  - Application commands (rates, marketcaps, compare, charts)
  - Database inspection commands
  - CI/quality check shortcuts
- Update README.md and CLAUDE.md with new command documentation