### PR TITLE
Fix markdown report bugs: gainers/losers filtering and double signs

### DIFF
--- a/src/specific_date_marketcaps.rs
+++ b/src/specific_date_marketcaps.rs
@@ -255,6 +255,7 @@ async fn export_specific_date_marketcaps(pool: &SqlitePool, date: NaiveDate) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Datelike;
 
     // Tests for format_rate function
     #[test]
@@ -388,6 +389,3 @@ mod tests {
         assert!(filename.ends_with(".csv"));
     }
 }
-
-// Additional helper for chrono
-use chrono::Datelike;


### PR DESCRIPTION
- Fix Top 10 Gainers section to only show companies with positive percentage changes
- Fix Top 10 Losers section to only show companies with negative percentage changes
- Fix Top 10 by Absolute Gain section to only show positive gains
- Fix Top 10 by Absolute Loss section for consistency (pre-filter instead of in-loop check)
- Fix double sign issue (+-3.33%) by only including positive percentages in gainers
- Fix incorrect "increase" label showing for negative values
- Use .abs() for decrease amounts in losers section
- Move chrono::Datelike import into tests module where it's used