### PR TITLE
Use original currency for market cap comparisons

### DIFF
--- a/src/advanced_comparisons.rs
+++ b/src/advanced_comparisons.rs
@@ -965,7 +965,7 @@ pub async fn compare_qoq(pool: &SqlitePool, reference_date: &str, num_quarters: 
 
 /// Perform rolling period comparison
 pub async fn compare_rolling(
-    pool: &SqlitePool,
+    _pool: &SqlitePool,
     reference_date: &str,
     period: RollingPeriod,
 ) -> Result<()> {
@@ -1004,7 +1004,7 @@ pub async fn compare_rolling(
     }
 
     // Use the existing comparison function
-    crate::compare_marketcaps::compare_market_caps(pool, &start_date_str, reference_date).await?;
+    crate::compare_marketcaps::compare_market_caps(&start_date_str, reference_date).await?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ async fn main() -> Result<()> {
             }
         }
         Some(Commands::CompareMarketCaps { from, to }) => {
-            compare_marketcaps::compare_market_caps(&pool, &from, &to).await?;
+            compare_marketcaps::compare_market_caps(&from, &to).await?;
         }
         Some(Commands::GenerateCharts { from, to }) => {
             visualizations::generate_all_charts(&from, &to).await?;


### PR DESCRIPTION
Remove currency conversion/normalization from compare_market_caps function
to show actual local currency performance instead of USD-normalized values.

Changes:
- Compare market caps using original currency values directly
- Add currency column to comparison CSV output
- Update Markdown summary to show values in original currency
- Remove exchange rate normalization and related imports
- Remove pool parameter from compare_market_caps (no longer needed)

The output now clearly shows each company's market cap change in its
native currency with appropriate disclaimers that absolute values
across different currencies are not directly comparable.