### PR TITLE
Add peer group and benchmark comparisons to daily email

### DIFF
--- a/.github/workflows/daily-specific-date.yml
+++ b/.github/workflows/daily-specific-date.yml
@@ -144,6 +144,38 @@ jobs:
             develop \
             --command bash -c "./target/release/top200-rs generate-charts --from ${{ steps.get-dates.outputs.month_ago }} --to ${{ steps.get-dates.outputs.today }}"
 
+      - name: Run peer group comparison (weekly)
+        run: |
+          echo "Running peer group comparison for week-over-week"
+          nix \
+            --extra-experimental-features "nix-command flakes" \
+            develop \
+            --command bash -c "./target/release/top200-rs compare-peer-groups --from ${{ steps.get-dates.outputs.week_ago }} --to ${{ steps.get-dates.outputs.today }}"
+
+      - name: Run peer group comparison (monthly)
+        run: |
+          echo "Running peer group comparison for month-over-month"
+          nix \
+            --extra-experimental-features "nix-command flakes" \
+            develop \
+            --command bash -c "./target/release/top200-rs compare-peer-groups --from ${{ steps.get-dates.outputs.month_ago }} --to ${{ steps.get-dates.outputs.today }}"
+
+      - name: Run benchmark comparison (weekly)
+        run: |
+          echo "Running benchmark comparison (S&P 500 proxy) for week-over-week"
+          nix \
+            --extra-experimental-features "nix-command flakes" \
+            develop \
+            --command bash -c "./target/release/top200-rs compare-benchmark --from ${{ steps.get-dates.outputs.week_ago }} --to ${{ steps.get-dates.outputs.today }} --benchmark sp500"
+
+      - name: Run benchmark comparison (monthly)
+        run: |
+          echo "Running benchmark comparison (S&P 500 proxy) for month-over-month"
+          nix \
+            --extra-experimental-features "nix-command flakes" \
+            develop \
+            --command bash -c "./target/release/top200-rs compare-benchmark --from ${{ steps.get-dates.outputs.month_ago }} --to ${{ steps.get-dates.outputs.today }} --benchmark sp500"
+
       - name: List generated files
         run: |
           echo "Generated files in output directory:"
@@ -161,6 +193,14 @@ jobs:
             output/comparison_${{ steps.get-dates.outputs.week_ago }}_to_${{ steps.get-dates.outputs.today }}_*.md
             output/comparison_${{ steps.get-dates.outputs.month_ago }}_to_${{ steps.get-dates.outputs.today }}_*.csv
             output/comparison_${{ steps.get-dates.outputs.month_ago }}_to_${{ steps.get-dates.outputs.today }}_*.md
+            output/peer_groups_${{ steps.get-dates.outputs.week_ago }}_to_${{ steps.get-dates.outputs.today }}_*.csv
+            output/peer_groups_${{ steps.get-dates.outputs.week_ago }}_to_${{ steps.get-dates.outputs.today }}_*.md
+            output/peer_groups_${{ steps.get-dates.outputs.month_ago }}_to_${{ steps.get-dates.outputs.today }}_*.csv
+            output/peer_groups_${{ steps.get-dates.outputs.month_ago }}_to_${{ steps.get-dates.outputs.today }}_*.md
+            output/benchmark_*_${{ steps.get-dates.outputs.week_ago }}_*.csv
+            output/benchmark_*_${{ steps.get-dates.outputs.week_ago }}_*.md
+            output/benchmark_*_${{ steps.get-dates.outputs.month_ago }}_*.csv
+            output/benchmark_*_${{ steps.get-dates.outputs.month_ago }}_*.md
             output/chart_*.svg
           retention-days: 90
 

--- a/send_brevo_email.sh
+++ b/send_brevo_email.sh
@@ -64,10 +64,31 @@ else
       <li>Month-over-month comparison (${MONTH_AGO_DATE} to ${TODAY_DATE})</li>
     </ul>
 
+    <h3 style=\"color: #8b5cf6;\">Peer Group Analysis:</h3>
+    <p style=\"font-size: 0.95em; color: #374151;\">Performance breakdown by industry segment:</p>
+    <ul>
+      <li><strong>Luxury</strong> - LVMH, Herm&egrave;s, Kering, Dior, Richemont, Moncler, Burberry, Prada</li>
+      <li><strong>Sportswear</strong> - Nike, Adidas, Puma, Lululemon, On Holding, Deckers, Skechers</li>
+      <li><strong>Fast Fashion</strong> - Inditex, H&amp;M, Fast Retailing, Gap, Abercrombie &amp; Fitch</li>
+      <li><strong>Value Retail</strong> - TJX Companies, Ross Stores, Burlington</li>
+      <li><strong>Footwear</strong> - Birkenstock, Crocs, Steve Madden, Ferragamo, Tod's</li>
+      <li><strong>E-commerce</strong> - Zalando, Vipshop, Revolve, ThredUp, Mytheresa</li>
+      <li><strong>Asian Fashion</strong> - Fast Retailing, Chow Tai Fook, Li Ning, Bosideng, Asics</li>
+    </ul>
+
+    <h3 style=\"color: #059669;\">Benchmark Comparison:</h3>
+    <p style=\"font-size: 0.95em; color: #374151;\">Performance vs S&amp;P 500 proxy (total market cap index):</p>
+    <ul>
+      <li>Identifies outperformers and underperformers relative to the market</li>
+      <li>Shows relative performance for each stock</li>
+    </ul>
+
     <h3>Generated Outputs:</h3>
     <ul>
       <li>Market cap CSV files for all three dates</li>
       <li>Comparison CSV and summary reports</li>
+      <li>Peer group analysis (CSV and Markdown summaries)</li>
+      <li>Benchmark comparison reports</li>
       <li>Visualization charts (SVG format)</li>
     </ul>
 


### PR DESCRIPTION
- Add peer group comparison steps (weekly and monthly) to workflow
- Add benchmark comparison (S&P 500 proxy) steps to workflow
- Update artifact upload patterns to include new output files
- Enhance email notification with peer group and benchmark sections
- Lists all 8 peer groups (Luxury, Sportswear, Fast Fashion, etc.)
- Explains benchmark comparison methodology